### PR TITLE
fix-setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,13 +4,3 @@ version = 0.1.0
 
 [options]
 packages = boto_plus
-install_requires =
-    boto3
-    fsspec
-    pandas
-    s3fs
-    moto
-    coverage
-    pytest
-    pytest-cov
-


### PR DESCRIPTION
The purpose of this PR is to remove the dependencies listed in the setup.cfg, they are instead listed in a requirements.txt file