### PR TITLE
rename-submodules

### DIFF
--- a/boto_plus/README.md
+++ b/boto_plus/README.md
@@ -1,4 +1,4 @@
-## S3Helper -- Public Functions
+## S3Plus -- Public Functions
 - `list_objects(bucket: str, prefix: str, filter='')`
 - `list_all_versions_of_object(bucket: str, key: str)`
 
@@ -28,6 +28,9 @@
 - `get_object_metadata(bucket: str, key: str)`
 - `get_bucket_and_key_from_uri(uri: str)`
 - `get_prefix_from_key(key: str)`
+
+## DynamoPlus -- Public Functions
+- `does_table_exist(table_name: str)`
 
 ### To-Do
 - create `delete_all_versions_of_all_objects_at_prefix()`

--- a/boto_plus/__init__.py
+++ b/boto_plus/__init__.py
@@ -1,10 +1,10 @@
 
-from .s3.s3_helper import (
-    S3Helper,
+from .s3_plus import (
+    S3Plus,
 )
 
-from .dynamo.dynamo_helper import (
-    DynamoHelper,
+from .dynamo_plus import (
+    DynamoPlus,
 )
 
 from .helpers import (
@@ -13,7 +13,6 @@ from .helpers import (
     get_local_file_hash,
     create_textfile,
     get_textfile_content,
-    get_bucket_and_key_from_s3_uri,
     get_filepaths_in_directory,
     is_windows_filepath,
     is_posix_filepath,

--- a/boto_plus/dynamo_plus.py
+++ b/boto_plus/dynamo_plus.py
@@ -2,7 +2,7 @@ import boto3
 import botocore
 
 
-class DynamoHelper:
+class DynamoPlus:
 
     def __init__(
         self,

--- a/boto_plus/s3_plus.py
+++ b/boto_plus/s3_plus.py
@@ -7,7 +7,7 @@ import botocore
 import boto_plus
 
 
-class S3Helper:
+class S3Plus:
 
     def __init__(
         self,
@@ -807,7 +807,7 @@ class S3Helper:
 
 
 if __name__ == '__main__':
-    s3_helper = boto_plus.S3Helper()
+    s3_helper = boto_plus.S3Plus()
     s3_helper.list_objects(
         bucket='astenger-test',
         prefix='sync-test/'

--- a/boto_plus/s3_plus.py
+++ b/boto_plus/s3_plus.py
@@ -491,8 +491,8 @@ class S3Plus:
         # run sequentially
         else:
             if sync_type == 's3-to-s3':
-                source_bucket, source_prefix = boto_plus.get_bucket_and_key_from_s3_uri(source)
-                target_bucket, target_prefix = boto_plus.get_bucket_and_key_from_s3_uri(target)
+                source_bucket, source_prefix = self.get_bucket_and_key_from_uri(source)
+                target_bucket, target_prefix = self.get_bucket_and_key_from_uri(target)
                 source_keys = self.list_objects(bucket=source_bucket, prefix=source_prefix)
 
                 for source_key in source_keys:
@@ -508,7 +508,7 @@ class S3Plus:
                     })
 
             elif sync_type == 'local-to-s3':
-                target_bucket, target_prefix = boto_plus.get_bucket_and_key_from_s3_uri(target)
+                target_bucket, target_prefix = self.get_bucket_and_key_from_uri(target)
                 source_filepaths = boto_plus.get_filepaths_in_directory(
                     local_directory=source,
                     recursive=True,
@@ -527,7 +527,7 @@ class S3Plus:
 
             elif sync_type == 's3-to-local':
                 os.makedirs(target, exist_ok=True)
-                source_bucket, source_prefix = boto_plus.get_bucket_and_key_from_s3_uri(source)
+                source_bucket, source_prefix = self.get_bucket_and_key_from_uri(source)
                 source_keys = self.list_objects(bucket=source_bucket, prefix=source_prefix)
                 for source_key in source_keys:
                     self.__sync_item({

--- a/boto_plus/s3_plus.py
+++ b/boto_plus/s3_plus.py
@@ -431,8 +431,8 @@ class S3Plus:
         # run in parallel with multiprocessing
         if use_multiprocessing:
             if sync_type == 's3-to-s3':
-                source_bucket, source_prefix = boto_plus.get_bucket_and_key_from_s3_uri(source)
-                target_bucket, target_prefix = boto_plus.get_bucket_and_key_from_s3_uri(target)
+                source_bucket, source_prefix = self.get_bucket_and_key_from_uri(source)
+                target_bucket, target_prefix = self.get_bucket_and_key_from_uri(target)
                 source_keys = self.list_objects(bucket=source_bucket, prefix=source_prefix)
                 payloads = [
                     {
@@ -454,7 +454,7 @@ class S3Plus:
                     recursive=True,
                 )
 
-                target_bucket, target_prefix = boto_plus.get_bucket_and_key_from_s3_uri(target)
+                target_bucket, target_prefix = self.get_bucket_and_key_from_uri(target)
                 payloads = [
                     {
                         'source-directory' : source,
@@ -470,7 +470,7 @@ class S3Plus:
 
             elif sync_type == 's3-to-local':
                 os.makedirs(target, exist_ok=True)
-                source_bucket, source_prefix = boto_plus.get_bucket_and_key_from_s3_uri(source)
+                source_bucket, source_prefix = self.get_bucket_and_key_from_uri(source)
                 source_keys = self.list_objects(bucket=source_bucket, prefix=source_prefix)
                 payloads = [
                     {

--- a/tests/test_s3_plus.py
+++ b/tests/test_s3_plus.py
@@ -32,7 +32,7 @@ class TestBotoPlus(unittest.TestCase):
         s3.put_object(Bucket=mock_bucket, Key='path/to/another/file.txt', Body='test-content-2')
         s3.put_object(Bucket=mock_bucket, Key='test.jpg')
 
-        s3_helper = boto_plus.S3Helper()
+        s3_helper = boto_plus.S3Plus()
 
         # test 1 -- general test of provided prefix
         objects = s3_helper.list_objects(bucket=mock_bucket, prefix='path/')
@@ -63,7 +63,7 @@ class TestBotoPlus(unittest.TestCase):
             content=mock_content,
         )
 
-        s3_helper = boto_plus.S3Helper()
+        s3_helper = boto_plus.S3Plus()
 
         # test 1 -- assert object and content are uploaded
         s3_helper.upload_object(
@@ -104,7 +104,7 @@ class TestBotoPlus(unittest.TestCase):
         s3.meta.client.create_bucket(Bucket=mock_bucket)
         s3.meta.client.put_object(Bucket=mock_bucket, Key=source_mock_key, Body=mock_content, Metadata={'x-amz-meta-object-hash' : 'abc123'})
 
-        s3_helper = boto_plus.S3Helper()
+        s3_helper = boto_plus.S3Plus()
 
         s3_helper.copy_object(
             source_bucket=mock_bucket,
@@ -137,7 +137,7 @@ class TestBotoPlus(unittest.TestCase):
         s3.meta.client.create_bucket(Bucket=mock_bucket)
         s3.meta.client.put_object(Bucket=mock_bucket, Key=source_mock_key, Body=mock_content, Metadata={'x-amz-meta-object-hash' : 'abc123'})
 
-        s3_helper = boto_plus.S3Helper()
+        s3_helper = boto_plus.S3Plus()
 
         s3_helper.move_object(
             source_bucket=mock_bucket,
@@ -175,7 +175,7 @@ class TestBotoPlus(unittest.TestCase):
         s3.meta.client.create_bucket(Bucket=mock_bucket)
         s3.meta.client.put_object(Bucket=mock_bucket, Key=mock_key, Body=mock_content, Metadata={'x-amz-meta-object-hash' : 'abc123'})
 
-        s3_helper = boto_plus.S3Helper()
+        s3_helper = boto_plus.S3Plus()
 
         s3_helper.delete_object(
             bucket=mock_bucket,
@@ -201,7 +201,7 @@ class TestBotoPlus(unittest.TestCase):
         mock_bucket = 'test-bucket'
 
         s3.meta.client.create_bucket(Bucket=mock_bucket)
-        s3_helper = boto_plus.S3Helper()
+        s3_helper = boto_plus.S3Plus()
 
         s3.meta.client.put_object(Bucket=mock_bucket, Key='s3-to-s3/inputs/subjects/1001/metadata/1001-metadata.csv', Body='column1\nvalue', Metadata={'x-amz-meta-object-hash' : 'abc123'})
         s3.meta.client.put_object(Bucket=mock_bucket, Key='s3-to-s3/inputs/subjects/1002/metadata/1002-metadata.csv', Body='column1\nvalue', Metadata={'x-amz-meta-object-hash' : 'def456'})
@@ -239,7 +239,7 @@ class TestBotoPlus(unittest.TestCase):
         mock_bucket = 'test-bucket'
 
         s3.create_bucket(Bucket=mock_bucket)
-        s3_helper = boto_plus.S3Helper()
+        s3_helper = boto_plus.S3Plus()
 
         s3.meta.client.put_object(Bucket=mock_bucket, Key='s3-to-local/inputs/subjects/1001/metadata/1001-metadata.csv', Body='column1\nvalue', Metadata={'x-amz-meta-object-hash' : 'abc123'})
         s3.meta.client.put_object(Bucket=mock_bucket, Key='s3-to-local/inputs/subjects/1002/metadata/1002-metadata.csv', Body='column2\nvalue', Metadata={'x-amz-meta-object-hash' : 'def456'})
@@ -278,7 +278,7 @@ class TestBotoPlus(unittest.TestCase):
         mock_bucket = 'test-bucket'
 
         s3.meta.client.create_bucket(Bucket=mock_bucket)
-        s3_helper = boto_plus.S3Helper()
+        s3_helper = boto_plus.S3Plus()
 
         os.makedirs('data/local-to-s3/local-inputs/subject/1001/', exist_ok=False)
         os.makedirs('data/local-to-s3/local-inputs/subject/1002/nested/', exist_ok=False)


### PR DESCRIPTION
The purpose of this Pull request is to 
- rename the S3Helper and DynamoHelper to S3Plus and DynamoPlus
- fix the renamed function calls that were previously missed (get_bucket_and_key_from_uri)