### PR TITLE
fix-time-return-type

### DIFF
--- a/boto_plus/batch_plus.py
+++ b/boto_plus/batch_plus.py
@@ -36,8 +36,8 @@ class BatchPlus:
         total_seconds = total.total_seconds()
 
         payload = {
-            'start' : start,
-            'stop'  : stop,
+            'start' : start.strftime("%Y-%m-%d %H:%M:%S"),
+            'stop'  : stop.strftime("%Y-%m-%d %H:%M:%S"),
             'total-seconds' : total_seconds,
         }
 


### PR DESCRIPTION
The purpose of this Pull Request is to change the type of the returned times for the BatchPlus function `get_runtime_from_batch_job()` to be strings instead of datetime objects.