### PR TITLE
make-batch-function-fail-hard

### DIFF
--- a/boto_plus/batch_plus.py
+++ b/boto_plus/batch_plus.py
@@ -29,6 +29,12 @@ class BatchPlus:
             ]
         )
 
+        # this should never happen -- so hard-fail if it does somehow
+        if len(response['jobs']) > 1:
+            error_str = f'More than one Batch jobs returned when calling "describe_jobs()" with job-id "{job_id}"'\
+                ' Please investigate further.'
+            raise RuntimeError(error_str)
+
         job_info = response['jobs'][0]
 
         start = dt.datetime.fromtimestamp(job_info['startedAt'] / 1000, tz=dt.timezone.utc)


### PR DESCRIPTION
The purpose of this Pull Request is to ensure the BatchPlus function `get_runtime_from_batch_job()` hard-fails if more than one job is found for the provided job ID. This scenario should never happen as job IDs are unique, so if it does somehow occur we need to catch it (possibly in-case a job is rerun with the same ID?)