### PR TITLE
get-runtime-accepts-multiple-job-ids

### DIFF
--- a/boto_plus/README.md
+++ b/boto_plus/README.md
@@ -1,5 +1,5 @@
 ## BatchPlus -- Public Functions
-- `get_runtime_from_batch_job(job_id: str)`
+- `get_runtime_of_jobs(job_ids: list[str])`
 - `get_status_of_jobs(job_ids: list[str])`
 
 ## DynamoPlus -- Public Functions


### PR DESCRIPTION
The purpose of this Pull Request is to adjust the `get_runtime_of_jobs` function to accept more than one job ID as input. The unit tests were also adjusted for this change.