### PR TITLE
add-dynamo-delete-functions

### DIFF
--- a/boto_plus/README.md
+++ b/boto_plus/README.md
@@ -8,6 +8,9 @@
 - `get_record_with_composite_key_from_table(primary_key: str, primary_key_value: any, secondary_key: str, secondary_key_value: any, dynamo_table: str)`
 - `get_records_with_attribute_from_table(attribute: str, attribute_value: any, dynamo_table: str)`
 - `put_record_in_table(record: dict, dynamo_table: str)`
+- `delete_record_with_primary_key_from_table(pk: str, pk_value: any, dynamo_table: str)`
+- `delete_record_with_composite_key_from_table(pk: str, pk_value: any, sk: str, sk_value: any, dynamo_table: str)`
+- `delete_records_with_attribute_from_table(attribute: str, attribute_value: any, pk: str, dynamo_table: str, sk=None)`
 
 ## S3Plus -- Public Functions
 - `list_objects(bucket: str, prefix: str, filter='')`

--- a/tests/test_dynamo_plus.py
+++ b/tests/test_dynamo_plus.py
@@ -109,14 +109,22 @@ class TestDynamoPlus(unittest.TestCase):
 
         self.assertEqual(record['other-field'], 'test')
 
-        # function raises error if the primary-key does not exist
-        self.assertRaises(
-            botocore.exceptions.ClientError,
-            dynamo_plus.get_record_with_primary_key_from_table,
-            'nonexistent-mock-field',  # pk
-            'def456',  # pk_value
-            'mock-table',  # dynamo_table
+        # function raises error if the primary-key field does not exist
+        with self.assertRaises(botocore.exceptions.ClientError):
+            dynamo_plus.get_record_with_primary_key_from_table(
+                pk='nonexistent-mock-field',
+                pk_value='def456',
+                dynamo_table='mock-table',
+            )
+
+        # function returns empty list if the primary key field's value is not present in any records
+        record = dynamo_plus.get_record_with_primary_key_from_table(
+            pk='mock-field',
+            pk_value='def456',
+            dynamo_table='mock-table',
         )
+        self.assertEqual(len(record), 0)
+
 
 
     @moto.mock_aws
@@ -176,16 +184,25 @@ class TestDynamoPlus(unittest.TestCase):
 
         self.assertEqual(record['other-field'], 'test')
 
-        # function raises error if the composite-key does not exist
-        self.assertRaises(
-            botocore.exceptions.ClientError,
-            dynamo_plus.get_record_with_composite_key_from_table,
-            'nonexistent-hash-field',  # pk
-            'v1',  # pk_value
-            'nonexistent-sort-field', #sk
-            'v2',  # sk_value
-            'mock-table',  # dynamo_table
+        # function raises error if one of the composite-key fields does not exist
+        with self.assertRaises(botocore.exceptions.ClientError):
+            dynamo_plus.get_record_with_composite_key_from_table(
+                pk='nonexistent-hash-field',
+                pk_value='v1',
+                sk='nonexistent-sort-field',
+                sk_value='v2',
+                dynamo_table='mock-table',
+            )
+
+        # function returns empty list if one of the composite-key field's value is not present in any records
+        record = dynamo_plus.get_record_with_composite_key_from_table(
+            pk='mock-field-hash',
+            pk_value='def456',
+            sk='mock-field-sort',
+            sk_value='mock-value',
+            dynamo_table='mock-table',
         )
+        self.assertEqual(len(record), 0)
 
 
     @moto.mock_aws
@@ -244,14 +261,21 @@ class TestDynamoPlus(unittest.TestCase):
         self.assertEqual(records[0]['mock-field-hash'], 'abc123')
         self.assertEqual(records[1]['mock-field-hash'], 'def456')
 
-        # function raises error if the attribute does not exist
-        self.assertRaises(
-            RuntimeError,
-            dynamo_plus.get_records_with_attribute_from_table,
-            'random-attribute',  # pk
-            'nonexistent-attribute-value',  # pk_value
-            'mock-table',  # dynamo_table
+        # function returns empty list if the attribute FIELD does not exist
+        record = dynamo_plus.get_records_with_attribute_from_table(
+            attribute='nonexistent-field',
+            attribute_value='nonexistent-attribute-value',
+            dynamo_table='mock-table',
         )
+        self.assertEqual(len(record), 0)
+
+        # function returns empty list if the attribute's value is not present in any records
+        record = dynamo_plus.get_records_with_attribute_from_table(
+            attribute='random-attribute',
+            attribute_value='not-real',
+            dynamo_table='mock-table',
+        )
+        self.assertEqual(len(record), 0)
 
 
     @moto.mock_aws
@@ -300,3 +324,170 @@ class TestDynamoPlus(unittest.TestCase):
         )
 
         self.assertEqual(response['Item']['random-attribute'], 'mock-attribute-value')
+
+
+    @moto.mock_aws
+    def test_delete_record_with_primary_key_from_table(self):
+        dynamo = boto3.resource('dynamodb', region_name=self.region)
+
+        dynamo.meta.client.create_table(
+            TableName='mock-table',
+            AttributeDefinitions=[
+                {
+                    'AttributeName': 'mock-field-hash',
+                    'AttributeType': 'S',
+                },
+            ],
+            KeySchema=[
+                {
+                    'AttributeName': 'mock-field-hash',
+                    'KeyType': 'HASH',
+                },
+            ],
+            BillingMode='provisioned',
+            ProvisionedThroughput={
+                'ReadCapacityUnits': 1,
+                'WriteCapacityUnits': 1,
+            },
+        )
+
+        dynamo.Table('mock-table').put_item(
+            Item={
+                'mock-field-hash' : 'abc123',
+            },
+        )
+
+        dynamo_plus = boto_plus.DynamoPlus(
+            boto_config=self.boto_config,
+            boto_session=self.boto_session,
+        )
+
+        dynamo_plus.delete_record_with_primary_key_from_table(
+            pk='mock-field-hash',
+            pk_value='abc123',
+            dynamo_table='mock-table',
+        )
+
+        # record was deleted
+        record = dynamo.Table('mock-table').get_item(
+            Key={
+                'mock-field-hash' : 'abc123',
+            }
+        )
+        self.assertNotIn('Item', record)
+              
+
+    @moto.mock_aws
+    def test_delete_record_with_composite_key_from_table(self):
+        dynamo = boto3.resource('dynamodb', region_name=self.region)
+
+        dynamo.meta.client.create_table(
+            TableName='mock-table',
+            AttributeDefinitions=[
+                {
+                    'AttributeName': 'mock-field-hash',
+                    'AttributeType': 'S',
+                },
+                {
+                    'AttributeName': 'mock-field-sort',
+                    'AttributeType': 'S',
+                },
+            ],
+            KeySchema=[
+                {
+                    'AttributeName': 'mock-field-hash',
+                    'KeyType': 'HASH',
+                },
+                {
+                    'AttributeName': 'mock-field-sort',
+                    'KeyType': 'RANGE',
+                },
+            ],
+            BillingMode='provisioned',
+            ProvisionedThroughput={
+                'ReadCapacityUnits': 1,
+                'WriteCapacityUnits': 1,
+            },
+        )
+
+        dynamo.Table('mock-table').put_item(
+            Item={
+                'mock-field-hash' : 'abc123',
+                'mock-field-sort' : 'sort123',
+            },
+        )
+
+        dynamo_plus = boto_plus.DynamoPlus(
+            boto_config=self.boto_config,
+            boto_session=self.boto_session,
+        )
+
+        dynamo_plus.delete_record_with_composite_key_from_table(
+            pk='mock-field-hash',
+            pk_value='abc123',
+            sk='mock-field-sort',
+            sk_value='sort123',
+            dynamo_table='mock-table',
+        )
+
+        # record was deleted
+        record = dynamo.Table('mock-table').get_item(
+            Key={
+                'mock-field-hash' : 'abc123',
+                'mock-field-sort' : 'sort123',
+            }
+        )
+        self.assertNotIn('Item', record)
+
+
+    @moto.mock_aws
+    def test_delete_records_with_attribute_from_table(self):
+        dynamo = boto3.resource('dynamodb', region_name=self.region)
+
+        dynamo.meta.client.create_table(
+            TableName='mock-table',
+            AttributeDefinitions=[
+                {
+                    'AttributeName': 'mock-field-hash',
+                    'AttributeType': 'S',
+                },
+            ],
+            KeySchema=[
+                {
+                    'AttributeName': 'mock-field-hash',
+                    'KeyType': 'HASH',
+                },
+            ],
+            BillingMode='provisioned',
+            ProvisionedThroughput={
+                'ReadCapacityUnits': 1,
+                'WriteCapacityUnits': 1,
+            },
+        )
+
+        dynamo.Table('mock-table').put_item(
+            Item={
+                'mock-field-hash' : 'abc123',
+                'attribute-field' : 'attribute123',
+            },
+        )
+
+        dynamo_plus = boto_plus.DynamoPlus(
+            boto_config=self.boto_config,
+            boto_session=self.boto_session,
+        )
+
+        dynamo_plus.delete_records_with_attribute_from_table(
+            attribute='attribute-field',
+            attribute_value='attribute123',
+            pk='mock-field-hash',
+            dynamo_table='mock-table',
+        )
+
+        # record was deleted
+        record = dynamo.Table('mock-table').get_item(
+            Key={
+                'mock-field-hash' : 'abc123',
+            }
+        )
+        self.assertNotIn('Item', record)


### PR DESCRIPTION
The purpose of this Pull Request is to add functions to the `DynamoPlus` class to delete records from the dynamo tables. Unittests were also added.