### PR TITLE
include-submodule-in-setup

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,10 @@ author = Andrew Stenger
 description = Wrapper library to make it easier to use the boto3 Python library. Work is in progress, leading up to Release v1.0.0
 
 [options]
-packages = boto_plus
+packages = 
+    boto_plus
+    boto_plus.helpers
+
 python_requires = >=3.9
 install_requires =
     setuptools==61.0


### PR DESCRIPTION
The purpose of this PR is to add the submodule `boto_plus.helpers` to the `setup.cfg` file (it was previously forgotten, and imports were not always working)