### PR TITLE
consolidate-dynamo-arg-names

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ Wrapper library to make it easier to use the boto3 Python library. Work is in pr
 ### DynamoPlus -- Public Functions
 - `does_table_exist(table_name: str)`
 - `get_all_records_from_table(table_name: str)`
-- `get_record_with_primary_key_from_table(primary_key: str, primary_key_value: any, dynamo_table: str)`
-- `get_record_with_composite_key_from_table(primary_key: str, primary_key_value: any, secondary_key: str, secondary_key_value: any, dynamo_table: str)`
-- `get_records_with_attribute_from_table(attribute: str, attribute_value: any, dynamo_table: str)`
-- `put_record_in_table(record: dict, dynamo_table: str)`
-- `delete_record_with_primary_key_from_table(pk: str, pk_value: any, dynamo_table: str)`
-- `delete_record_with_composite_key_from_table(pk: str, pk_value: any, sk: str, sk_value: any, dynamo_table: str)`
-- `delete_records_with_attribute_from_table(attribute: str, attribute_value: any, pk: str, dynamo_table: str, sk=None)`
+- `get_record_with_primary_key_from_table(primary_key: str, primary_key_value: any, table_name: str)`
+- `get_record_with_composite_key_from_table(primary_key: str, primary_key_value: any, secondary_key: str, secondary_key_value: any, table_name: str)`
+- `get_records_with_attribute_from_table(attribute: str, attribute_value: any, table_name: str)`
+- `put_record_in_table(record: dict, table_name: str)`
+- `delete_record_with_primary_key_from_table(pk: str, pk_value: any, table_name: str)`
+- `delete_record_with_composite_key_from_table(pk: str, pk_value: any, sk: str, sk_value: any, table_name: str)`
+- `delete_records_with_attribute_from_table(attribute: str, attribute_value: any, pk: str, table_name: str, sk=None)`
 
 ### StepFunctionPlus -- Public Functions
 - `does_state_machine_exist(name: str, version=None)`

--- a/boto_plus/dynamo_plus.py
+++ b/boto_plus/dynamo_plus.py
@@ -85,9 +85,9 @@ class DynamoPlus:
         self,
         pk: str,
         pk_value: any,
-        dynamo_table: str,
+        table_name: str,
     ) -> dict:
-        response = self.__dynamo_resource.Table(dynamo_table).get_item(
+        response = self.__dynamo_resource.Table(table_name).get_item(
             Key={
                 pk : pk_value,
             }
@@ -106,9 +106,9 @@ class DynamoPlus:
         pk_value: any,
         sk: str,
         sk_value: any,
-        dynamo_table: str,
+        table_name: str,
     ) -> dict:
-        response = self.__dynamo_resource.Table(dynamo_table).get_item(
+        response = self.__dynamo_resource.Table(table_name).get_item(
             Key={
                 pk : pk_value,
                 sk : sk_value,
@@ -126,13 +126,13 @@ class DynamoPlus:
         self,
         attribute: str,
         attribute_value: any,
-        dynamo_table: str,
+        table_name: str,
     ) -> list[dict]:
         """
         Get the records for the (non-primary key) attribute from the provided
         dynamo table.
         """
-        response = self.__dynamo_resource.Table(dynamo_table).scan(
+        response = self.__dynamo_resource.Table(table_name).scan(
             FilterExpression=boto3.dynamodb.conditions.Attr(attribute).eq(attribute_value)
         )
 
@@ -146,9 +146,9 @@ class DynamoPlus:
     def put_record_in_table(
         self,
         record: dict,
-        dynamo_table: str,
+        table_name: str,
     ):
-        self.__dynamo_resource.Table(dynamo_table).put_item(
+        self.__dynamo_resource.Table(table_name).put_item(
             Item=record,
         )
 
@@ -157,9 +157,9 @@ class DynamoPlus:
         self,
         pk: str,
         pk_value: any,
-        dynamo_table: str,
+        table_name: str,
     ) -> dict:
-        response = self.__dynamo_resource.Table(dynamo_table).delete_item(
+        response = self.__dynamo_resource.Table(table_name).delete_item(
             Key={
                 pk : pk_value,
             }
@@ -174,9 +174,9 @@ class DynamoPlus:
         pk_value: any,
         sk: str,
         sk_value: any,
-        dynamo_table: str,
+        table_name: str,
     ) -> dict:
-        response = self.__dynamo_resource.Table(dynamo_table).delete_item(
+        response = self.__dynamo_resource.Table(table_name).delete_item(
             Key={
                 pk : pk_value,
                 sk : sk_value,
@@ -191,12 +191,12 @@ class DynamoPlus:
         attribute: str,
         attribute_value: any,
         pk: str,
-        dynamo_table: str,
+        table_name: str,
         sk=None,
     ) -> dict:
-        table = self.__dynamo_resource.Table(dynamo_table)
+        table = self.__dynamo_resource.Table(table_name)
 
-        scan_response = self.__dynamo_resource.Table(dynamo_table).scan(
+        scan_response = self.__dynamo_resource.Table(table_name).scan(
             FilterExpression=boto3.dynamodb.conditions.Attr(attribute).eq(attribute_value)
         )
 

--- a/tests/test_dynamo_plus.py
+++ b/tests/test_dynamo_plus.py
@@ -104,7 +104,7 @@ class TestDynamoPlus(unittest.TestCase):
         record = dynamo_plus.get_record_with_primary_key_from_table(
             pk='mock-field',
             pk_value='abc123',
-            dynamo_table='mock-table',
+            table_name='mock-table',
         )
 
         self.assertEqual(record['other-field'], 'test')
@@ -114,14 +114,14 @@ class TestDynamoPlus(unittest.TestCase):
             dynamo_plus.get_record_with_primary_key_from_table(
                 pk='nonexistent-mock-field',
                 pk_value='def456',
-                dynamo_table='mock-table',
+                table_name='mock-table',
             )
 
         # function returns empty list if the primary key field's value is not present in any records
         record = dynamo_plus.get_record_with_primary_key_from_table(
             pk='mock-field',
             pk_value='def456',
-            dynamo_table='mock-table',
+            table_name='mock-table',
         )
         self.assertEqual(len(record), 0)
 
@@ -179,7 +179,7 @@ class TestDynamoPlus(unittest.TestCase):
             pk_value='abc123',
             sk='mock-field-sort',
             sk_value='def456',
-            dynamo_table='mock-table',
+            table_name='mock-table',
         )
 
         self.assertEqual(record['other-field'], 'test')
@@ -191,7 +191,7 @@ class TestDynamoPlus(unittest.TestCase):
                 pk_value='v1',
                 sk='nonexistent-sort-field',
                 sk_value='v2',
-                dynamo_table='mock-table',
+                table_name='mock-table',
             )
 
         # function returns empty list if one of the composite-key field's value is not present in any records
@@ -200,7 +200,7 @@ class TestDynamoPlus(unittest.TestCase):
             pk_value='def456',
             sk='mock-field-sort',
             sk_value='mock-value',
-            dynamo_table='mock-table',
+            table_name='mock-table',
         )
         self.assertEqual(len(record), 0)
 
@@ -254,7 +254,7 @@ class TestDynamoPlus(unittest.TestCase):
         records = dynamo_plus.get_records_with_attribute_from_table(
             attribute='random-attribute',
             attribute_value='mock-attribute-value',
-            dynamo_table='mock-table',
+            table_name='mock-table',
         )
 
         self.assertEqual(len(records), 2)
@@ -265,7 +265,7 @@ class TestDynamoPlus(unittest.TestCase):
         record = dynamo_plus.get_records_with_attribute_from_table(
             attribute='nonexistent-field',
             attribute_value='nonexistent-attribute-value',
-            dynamo_table='mock-table',
+            table_name='mock-table',
         )
         self.assertEqual(len(record), 0)
 
@@ -273,7 +273,7 @@ class TestDynamoPlus(unittest.TestCase):
         record = dynamo_plus.get_records_with_attribute_from_table(
             attribute='random-attribute',
             attribute_value='not-real',
-            dynamo_table='mock-table',
+            table_name='mock-table',
         )
         self.assertEqual(len(record), 0)
 
@@ -313,7 +313,7 @@ class TestDynamoPlus(unittest.TestCase):
                 'mock-field-hash' : 'abc123',
                 'random-attribute' : 'mock-attribute-value',
             },
-            dynamo_table='mock-table',
+            table_name='mock-table',
         )
 
         # function retrieves records for the provided attribute
@@ -365,7 +365,7 @@ class TestDynamoPlus(unittest.TestCase):
         dynamo_plus.delete_record_with_primary_key_from_table(
             pk='mock-field-hash',
             pk_value='abc123',
-            dynamo_table='mock-table',
+            table_name='mock-table',
         )
 
         # record was deleted
@@ -427,7 +427,7 @@ class TestDynamoPlus(unittest.TestCase):
             pk_value='abc123',
             sk='mock-field-sort',
             sk_value='sort123',
-            dynamo_table='mock-table',
+            table_name='mock-table',
         )
 
         # record was deleted
@@ -481,7 +481,7 @@ class TestDynamoPlus(unittest.TestCase):
             attribute='attribute-field',
             attribute_value='attribute123',
             pk='mock-field-hash',
-            dynamo_table='mock-table',
+            table_name='mock-table',
         )
 
         # record was deleted


### PR DESCRIPTION
The purpose of this PR is to consolidate all the Dynamo table name args in the Dynamo functions to all be `table_name`. Previously some of these functions were using `dynamo_table` -- we should keep them all consistent to make the library more predictable.